### PR TITLE
Specify -std=c99 to fix compiler error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 all: 
-	$(CC) *.c -Wall -Werror -o jack -g
+	$(CC) *.c -Wall -Werror -std=c99 -o jack -g


### PR DESCRIPTION
Occurred in multiple places when using GNU cc 4.9.1. Example:

```
cc *.c -Wall -Werror -o jack -g
api.c: In function ‘jack_xmove’:
api.c:357:3: error: ‘for’ loop initial declarations are only allowed in C99 or C11 mode
   for (int i = 0; i < num; ++i) {
   ^
api.c:357:3: note: use option -std=c99, -std=gnu99, -std=c11 or -std=gnu11 to compile your code
```

Closes #1
